### PR TITLE
[zomeki:00770] Re: イベントのテーブルのタグ 対応しました。

### DIFF
--- a/app/views/portal_calendar/public/node/events/index_calendar.html.erb
+++ b/app/views/portal_calendar/public/node/events/index_calendar.html.erb
@@ -41,7 +41,6 @@
 		<% if this_day[:events].size > 0 %>
 		  <ul>
 		  <% this_day[:events].each do |item| %>
-			<% next unless item.attr_exists? %>
 			<li><%= item.event_uri.blank? ? hbr(item.title) : link_to(hbr(item.title), item.event_uri, :target => "_blank") %></li>
 		  <% end %>
 		  </ul>

--- a/app/views/portal_calendar/public/node/lists/index_monthly.html.erb
+++ b/app/views/portal_calendar/public/node/lists/index_monthly.html.erb
@@ -22,11 +22,10 @@
 		<% end %>
 
 		<% @items[day[:date]].each do |item| %>
-		  <% next unless item.attr_exists? %>
 		  <%= content_tag(:tr) do  %>
-			<%= content_tag(:td, get_genre_title(item), :class=>'event_genre') %>
-		    <%= content_tag(:td, link_to_if(item.event_uri.present?, item.title, item.event_uri, :target => "_blank"), :class=>'event_title') %>
-			<%= content_tag(:td, get_status_title(item), :class=>'event_status') %>
+			<%= content_tag(:td, get_genre_title(item), :class=>'event_genre') if item.genre_exists? %>
+			<%= content_tag(:td, link_to_if(item.event_uri.present?, item.title, item.event_uri, :target => "_blank"), :class=>'event_title') %>
+			<%= content_tag(:td, get_status_title(item), :class=>'event_status') if item.status_exists? %>
 		  <% end %>
 		<% end %>
 		</table>


### PR DESCRIPTION
・ジャンル、ステータスが設定されていない場合、tdタグを打たないようにしました。
・ジャンル、ステータス両方設定されていないイベントを表示させるように戻しました。

Signed-off-by: Kouichi AZUMA azuma@idsinc.co.jp
