### PR TITLE
ホームページ記事のアーカイブで、アーカイブノードのURLが取得できていなかった状況を解消。

### DIFF
--- a/app/controllers/portal_article/public/piece/archives_controller.rb
+++ b/app/controllers/portal_article/public/piece/archives_controller.rb
@@ -20,7 +20,7 @@ class PortalArticle::Public::Piece::ArchivesController < Sys::Controller::Public
   def index
     @piece   = Page.current_piece
     @content = PortalArticle::Content::Doc.find(@piece.content_id)
-    @node = @content.recent_node
+    @node = @content.archive_node
 		
     limit = Page.current_piece.setting_value(:list_count)
     limit = (limit.to_s =~ /^[1-9][0-9]*$/) ? limit.to_i : 10
@@ -46,6 +46,6 @@ class PortalArticle::Public::Piece::ArchivesController < Sys::Controller::Public
 		end
 		
 		@lists = get_count(edate, sdate, @piece.content_id, show_count_zero)
-		@base_uri = Page.current_node.public_uri
+		@base_uri = @node.public_uri
   end
 end

--- a/app/models/portal_article/content/doc.rb
+++ b/app/models/portal_article/content/doc.rb
@@ -37,6 +37,14 @@ class PortalArticle::Content::Doc < Cms::Content
     item.and :model, 'PortalArticle::RecentDoc'
     @recent_node = item.find(:first, :order => :id)
   end
+
+  def archive_node
+    return @archive_node if @archive_node
+    item = Cms::Node.new.public
+    item.and :content_id, id
+    item.and :model, 'PortalArticle::Archive'
+    @archive_node = item.find(:first, :order => :id)
+  end
   
   def portal_category_node
     return @portal_category_node if @portal_category_node


### PR DESCRIPTION
ホームページ記事 portal_article のアーカイブピースに含まれる「年月」のリンクがページURLを元に作られていたため、リンク先であるアーカイブノードが正しく表示できていませんでした。
アーカイブノードのURIでリンクを作成するように変更しました。
