### PR TITLE
Repaired an error when I updated "create" of "sys_object_privileges".

### DIFF
--- a/lib/sys/controller/scaffold/base.rb
+++ b/lib/sys/controller/scaffold/base.rb
@@ -42,7 +42,7 @@ protected
   
   def _update(item, options = {}, &block)
     if item.editable? && item.save
-      item.reload if item.respond_to?(:reload)
+      item.reload if item.respond_to?(:reload) rescue nil
       location       = options[:location] || url_for(:action => :index)
       flash[:notice] = '更新処理が完了しました。'
       yield if block_given?


### PR DESCRIPTION
権限編集画面にて「新規」のチェックを外して編集ボタンを押した際に発生する

> 403 Forbidden ( アクセス権限がありません。 )

を回避しました。
